### PR TITLE
Allow low/high distance auto-fuzziness syntax in setFuzzyness().

### DIFF
--- a/src/AbstractFuzzyQuery.php
+++ b/src/AbstractFuzzyQuery.php
@@ -80,6 +80,12 @@ abstract class AbstractFuzzyQuery extends AbstractQuery
                 if ($this->fuzzyness === self::FUZZY_AUTO) {
                     $raw .= '~';
                 }
+                elseif (strpos($this->fuzzyness, self::FUZZY_AUTO . ':') === 0) {
+                    list ($low, $high) = explode(',', substr($this->fuzzyness, strlen(self::FUZZY_AUTO . ':')));
+                    $length = strlen($raw);
+                    $fuzzyness = $length < $low ? 0 : ($length >= $high ? 2 : 1);
+                    $raw .= '~' . $fuzzyness;
+                }
                 else {
                     $raw .= '~' . $this->fuzzyness;
                 }

--- a/src/AbstractFuzzyQuery.php
+++ b/src/AbstractFuzzyQuery.php
@@ -30,9 +30,9 @@ abstract class AbstractFuzzyQuery extends AbstractQuery
      */
     public function setFuzzyness($fuzzyness)
     {
-        if ($fuzzyness != NULL && $fuzzyness !== self::FUZZY_AUTO && (! is_numeric($fuzzyness) || $fuzzyness < 0)
-          || (strpos($fuzzyness, self::FUZZY_AUTO . ':') === 0 && !is_numeric(str_replace(',', '', substr($fuzzyness, strlen(self::FUZZY_AUTO . ':')))))
-        ) {
+        if (!($fuzzyness == NULL || $fuzzyness === self::FUZZY_AUTO || (is_numeric($fuzzyness) && $fuzzyness >= 0)
+          || (strpos($fuzzyness, self::FUZZY_AUTO . ':') === 0 && is_numeric(str_replace(',', '', substr($fuzzyness, strlen(self::FUZZY_AUTO . ':')))))
+        )) {
             throw new \InvalidArgumentException("Fuzyness/roaming value must be a positive integer, " . print_r($fuzzyness, TRUE) . " given");
         }
 

--- a/src/AbstractFuzzyQuery.php
+++ b/src/AbstractFuzzyQuery.php
@@ -30,7 +30,9 @@ abstract class AbstractFuzzyQuery extends AbstractQuery
      */
     public function setFuzzyness($fuzzyness)
     {
-        if ($fuzzyness != NULL && $fuzzyness !== self::FUZZY_AUTO && (! is_numeric($fuzzyness) || $fuzzyness < 0)) {
+        if ($fuzzyness != NULL && $fuzzyness !== self::FUZZY_AUTO && (! is_numeric($fuzzyness) || $fuzzyness < 0)
+          || (strpos($fuzzyness, self::FUZZY_AUTO . ':') === 0 && !is_numeric(str_replace(',', '', substr($fuzzyness, strlen(self::FUZZY_AUTO . ':')))))
+        ) {
             throw new \InvalidArgumentException("Fuzyness/roaming value must be a positive integer, " . print_r($fuzzyness, TRUE) . " given");
         }
 


### PR DESCRIPTION
This allows the auto-fuzziness format 'AUTO:<low>,<high>' documented at https://www.elastic.co/guide/en/elasticsearch/reference/7.6/common-options.html#fuzziness.