### PR TITLE
Fix PHP 8.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
     },
     "minimum-stability" : "dev",
     "prefer-stable" : true,
+    "require": {
+        "php": ">=7.0"
+    },
     "require-dev" : {
         "phpunit/phpunit" : "^9.5",
         "phpstan/phpstan-deprecation-rules": "^1.0",

--- a/src/CollectionQuery.php
+++ b/src/CollectionQuery.php
@@ -21,8 +21,7 @@ class CollectionQuery extends AbstractQuery implements
     /**
      * {@inheritdoc}
      */
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->elements);
     }
@@ -30,8 +29,7 @@ class CollectionQuery extends AbstractQuery implements
     /**
      * {@inheritdoc}
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->elements);
     }

--- a/src/CollectionQuery.php
+++ b/src/CollectionQuery.php
@@ -21,6 +21,7 @@ class CollectionQuery extends AbstractQuery implements
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->elements);
@@ -29,6 +30,7 @@ class CollectionQuery extends AbstractQuery implements
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->elements);


### PR DESCRIPTION
* [CollectionQuery::getIterator][CollectionQuery::getIterator] should have a return type `Traversable` to be compatible with [IteratorAggregate][IteratorAggregate]. Marked with the [ReturnTypeWillChange][ReturnTypeWillChange] attribute to make it forward compatible without losing backward compatibility.

* [CollectionQuery::count][CollectionQuery::count] should have a return type `int` to be compatible with [Countable][Countable]. Marked with the [ReturnTypeWillChange][ReturnTypeWillChange] attribute to make it forward compatible without losing backward compatibility.

[ReturnTypeWillChange]: https://php.watch/versions/8.1/ReturnTypeWillChange
[IteratorAggregate]: https://www.php.net/manual/en/class.iteratoraggregate.php
[Countable]: https://www.php.net/manual/en/class.countable.php
[CollectionQuery::getIterator]: https://github.com/makinacorpus/php-lucene-query/blob/85493f5b43d00a56c20e56b2098849f6e6dbe127/src/CollectionQuery.php#L21-L27
[CollectionQuery::count]: https://github.com/makinacorpus/php-lucene-query/blob/85493f5b43d00a56c20e56b2098849f6e6dbe127/src/CollectionQuery.php#L29-L35